### PR TITLE
Add (empty) unit tests

### DIFF
--- a/test/testthat.R
+++ b/test/testthat.R
@@ -1,0 +1,1 @@
+test_that("test skeleton", { })


### PR DESCRIPTION
Adding empty unit tests to get testing effort started.

In order to make this useful, a lot of the logic inside of the shiny server function will have to be moved into testable units.